### PR TITLE
Unable to delete a message using the API (from zmta-webadmin, for example)

### DIFF
--- a/config/bounces.txt
+++ b/config/bounces.txt
@@ -212,8 +212,9 @@
 
 # Yahoo error messages
 # https://help.yahoo.com/kb/SLN23996.html
-^421[ \-]+4\.7\.0 \[TS0[12]\],reject,spam,Users complain about spam from this sender
-^421[ \-]+4\.7\.0 \[TS03\],defer,blacklist,Sender IP blocked
+# https://help.yahoo.com/kb/postmaster/SLN3434.html
+^421[ \-]+4\.7\.0,defer,spam,Unusual traffic or users complain about spam from this sender
+^421[ \-]+4\.7\.1,reject,blacklist,Sender IP blocked
 ^451[ \-]+VS1\-IP\b,reject,block,Sender is open relay
 ^451[ \-]+VS1\-MF\b,reject,spam,From address is spammer
 ^553[ \-]+5\.7\.1 \[BL,defer,blacklist,Blacklisted by Spamhaus

--- a/lib/mail-queue.js
+++ b/lib/mail-queue.js
@@ -577,14 +577,13 @@ class MailQueue {
                 id: true,
                 seq: true
             },
-            {},
             (err, cursor) => {
                 if (err) {
                     return callback(err);
                 }
 
                 let releaseNext = () => {
-                    cursor.nextObject((err, delivery) => {
+                    cursor.next((err, delivery) => {
                         if (err) {
                             this.locks.releaseLockOwner(deleteId);
                             return callback(err);


### PR DESCRIPTION
DELETE /messages/:id/ was timeouting and the following message was logged: "Third parameter to `find()` must be a callback or undefined". Also had to change `nextObject()` to `next()` in the cursor.