### PR TITLE
Making it clearer when the DB connection problem is with Redis.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -20,19 +20,19 @@ let getRedisConnection = callback => {
     let redisReturned = false;
     let redis = new Redis(module.exports.redisConfig);
     redis.on('error', err => {
+        log.error('Redis/' + process.pid, '%s', err.message);
         if (!redisReturned) {
             redisReturned = true;
             return callback(err);
         }
-        log.error('Redis/' + process.pid, '%s', err.message);
     });
     redis.once('ready', () => {
         module.exports.redis = redis;
+        log.info('Redis/' + process.pid, 'Redis ready to take connections');
         if (!redisReturned) {
             redisReturned = true;
             return callback(null, true);
         }
-        log.info('Redis/' + process.pid, 'Redis ready to take connections');
     });
 };
 

--- a/lib/mail-queue.js
+++ b/lib/mail-queue.js
@@ -1204,7 +1204,7 @@ class MailQueue {
 
         db.connect(err => {
             if (err) {
-                log.error('Queue', 'Could not initialize MongoDB: %s', err.message);
+                log.error('Queue', 'Could not initialize database: %s', err.message);
                 return process.exit(1);
             }
 


### PR DESCRIPTION
When there is a problem with the Redis connection, the error message says MongoDB:

```
ERR! Queue Could not initialize MongoDB: connect ECONNREFUSED 127.0.0.1:63799
```

To make it clearer, I suggest moving the log.error() and log.info() calls early in the callback and change the error message to a generic 'Could not initialize database'.

```
ERR! Redis/17626 connect ECONNREFUSED 127.0.0.1:63799
ERR! Queue Could not initialize database: connect ECONNREFUSED 127.0.0.1:63799
```