### PR TITLE
Fixes #174: plugins fail to load on Windows

### DIFF
--- a/lib/plugin-handler.js
+++ b/lib/plugin-handler.js
@@ -211,7 +211,7 @@ class PluginHandler {
 
             try {
                 let loadStartTime = Date.now();
-                if (plugin.path.indexOf('/') < 0) {
+                if (plugin.path.indexOf('/') < 0 && plugin.path.indexOf('\\') < 0) {
                     plugin.path = path.join(process.cwd(), 'node_modules', plugin.path);
                 }
                 plugin.module = require(plugin.path); // eslint-disable-line global-require


### PR DESCRIPTION
Plugins fail to load on Windows because path separators are not respected.