### PR TITLE
Adding queue:defer hook

### DIFF
--- a/lib/queue-server.js
+++ b/lib/queue-server.js
@@ -176,25 +176,32 @@ class QueueServer {
                                 error: 'Zone not set'
                             });
                         }
-                        deliveryStatusCounter.inc({
-                            status: 'deferred'
-                        });
-                        return this.deferDelivery(client.zone, client.id, data, (err, response) => {
-                            if (!client) {
-                                // client already errored or closed
-                                return;
-                            }
-                            if (err) {
-                                return client.send({
-                                    req: data.req,
-                                    error: err.message || err
+                        plugins.handler.runHooks(
+                            'queue:defer',
+                            [data],
+                            () => {
+                                deliveryStatusCounter.inc({
+                                    status: 'deferred'
+                                });
+                                return this.deferDelivery(client.zone, client.id, data, (err, response) => {
+                                    if (!client) {
+                                        // client already errored or closed
+                                        return;
+                                    }
+                                    if (err) {
+                                        return client.send({
+                                            req: data.req,
+                                            error: err.message || err
+                                        });
+                                    }
+                                    client.send({
+                                        req: data.req,
+                                        response
+                                    });
                                 });
                             }
-                            client.send({
-                                req: data.req,
-                                response
-                            });
-                        });
+                        );
+                        break;
 
                     case 'BOUNCE':
                         {


### PR DESCRIPTION
Having a queue:defer hook is useful so you can look into delivery problems before they turn into bounces.

Based on this hook, I created a plugin that warns me on Sentry when a message has been deferred:

```nodejs
'use strict';

const raven = require('raven');

module.exports.title = 'Zenmail Deferred Log';
module.exports.init = function(app, done) {

	raven.config(app.config.dsn).install();

	app.addHook('queue:defer', (data, next) => {
		raven.captureMessage('Deferred: ' + data.response, {extra: data});
		next();
	});

	done();
};
```