### PR TITLE
Make default zone configurable

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -36,7 +36,10 @@ module.exports = {
         collection: 'zone-queue',
 
         // set to true if you do not want old data to be removed
-        disableGC: false
+        disableGC: false,
+
+        // default zone for any other mail not specified by zone
+        defaultZone: 'default'
     },
 
     // plugin files to load into ZoneMTA, relative to ./plugins folder

--- a/lib/mail-queue.js
+++ b/lib/mail-queue.js
@@ -277,7 +277,7 @@ class MailQueue {
 
             // still nothing, use default
             if (!deliveryZone) {
-                deliveryZone = 'default';
+                deliveryZone = this.options.defaultZone || 'default';
             }
 
             let routing = {
@@ -378,7 +378,7 @@ class MailQueue {
             return callback(null, false);
         }
 
-        zone = zone || 'default';
+        zone = zone || (this.options.defaultZone || 'default');
         options = options || {};
 
         if (this.cache.get('empty:' + zone)) {


### PR DESCRIPTION
Made the default zone configurable. 
We had/have e.g. the case that we do not want to share the default zone but the other zones in the queue are shared.