### PR TITLE
Fixing orphaned FIN_WAIT2 sockets

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -891,7 +891,6 @@ class Sender extends EventEmitter {
                 if (err) {
                     // could not connect to MX
                     log.error(this.logName, '%s.%s ERRCONNECT domain=%s error=%s', delivery.id, delivery.seq, delivery.domain, err.message);
-
                     return callback(err);
                 }
 
@@ -935,7 +934,7 @@ class Sender extends EventEmitter {
                     authMethod: this.zone.authMethod,
 
                     connectionTimeout: 5 * 60 * 1000,
-                    greetingTimeout: 0.5 * 60 * 1000,
+                    greetingTimeout: 2 * 60 * 1000,
 
                     tls: {
                         servername: mx.hostname,

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1032,7 +1032,9 @@ class Sender extends EventEmitter {
                     // There a some buggy clients with a buggy TCP stack.
                     // We are destroying the socket to remove FIN_WAIT2 connections and freeing up FDs and memory
                     setTimeout(() => {
-                        connection._socket.destroy();
+			            if (connection._socket && !connection._socket.destroyed) {
+                            connection._socket.destroy();
+                        }
                     }, 1000);
 
                     if (returned) {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -891,6 +891,7 @@ class Sender extends EventEmitter {
                 if (err) {
                     // could not connect to MX
                     log.error(this.logName, '%s.%s ERRCONNECT domain=%s error=%s', delivery.id, delivery.seq, delivery.domain, err.message);
+
                     return callback(err);
                 }
 
@@ -934,7 +935,7 @@ class Sender extends EventEmitter {
                     authMethod: this.zone.authMethod,
 
                     connectionTimeout: 5 * 60 * 1000,
-                    greetingTimeout: 2 * 60 * 1000,
+                    greetingTimeout: 0.5 * 60 * 1000,
 
                     tls: {
                         servername: mx.hostname,
@@ -1027,6 +1028,14 @@ class Sender extends EventEmitter {
                         (Date.now() - startTime) / 1000
                     );
                     connection.connected = false;
+
+                    // Give some time to clear connection
+                    // There a some buggy clients with a buggy TCP stack.
+                    // We are destroying the socket to remove FIN_WAIT2 connections and freeing up FDs and memory
+                    setTimeout(() => {
+                        connection._socket.destroy();
+                    }, 1000);
+
                     if (returned) {
                         return;
                     }


### PR DESCRIPTION
While monitoring the connection pool feature i found a strange bug/behaviour.

Some MTA out there having a buggy TCP stack and closing the connection not correctly.
So we had the problem that we have tons of open connection in state FIN_WAIT2.

This happened on connections where we haven't received any greeting. 
Zone wants to close the connection, sends a FIN, gets a ACK and than waits for the remote-side to close. 

Now we give the remote-side some time to close it correctly after that we destroy the socket.