### PR TITLE
Check for the accessibility of certs

### DIFF
--- a/lib/smtp-interface.js
+++ b/lib/smtp-interface.js
@@ -71,8 +71,16 @@ class SMTPInterface {
             if (Buffer.isBuffer(file) || /\n/.test(file)) {
                 return done(null, file);
             }
-            // otherwise try to load contents from a file path
-            fs.readFile(file, done);
+
+			// otherwise try to load contents from a file path
+			fs.access(file, fs.R_OK, (err) => {
+				if (err) {
+					log.error(this.logName, 'SERVERR error=%s', err.message);
+					return done(err, null);
+				}
+				//file exists or allowable permission access
+				fs.readFile(file, done);
+            });
         };
 
         let getKeyfiles = done => {


### PR DESCRIPTION
 This patch test the permission of a given cert file. The permissions checked if it is readable.

I had issue on this error 
```BASH
SERVERR error=140569775089536:error:1417A0C1:SSL routines:tls_post_process_client_hello:no shared cipher:../deps/openssl/openssl/ssl/statem/statem_srvr.c:2284:
```
There wasn't much helped on the log. As the certs have no problems running on other services such as haraka. Checked file path and verified the cert still zone-mta have problems loading it. After i debugged found out that somehow the file was denied to be read for zone-mta service. Quick fix with chown and and resolved it. Hopefully, this patch will save hours of debugging.
