### PR TITLE
do not update delivery.sendingZone with metadata sendingZone

### DIFF
--- a/lib/mail-queue.js
+++ b/lib/mail-queue.js
@@ -477,7 +477,9 @@ class MailQueue {
                         }
 
                         Object.keys(meta || {}).forEach(key => {
-                            delivery[key] = meta[key];
+                            if (key != 'sendingZone') {
+                                delivery[key] = meta[key];
+                            }
                         });
 
                         let data = {};

--- a/lib/queue-server.js
+++ b/lib/queue-server.js
@@ -403,7 +403,9 @@ class QueueServer {
                 }
 
                 Object.keys(meta || {}).forEach(key => {
-                    delivery[key] = meta[key];
+                    if (key != 'sendingZone') {
+                        delivery[key] = meta[key];
+                    }
                 });
 
                 let data = {};


### PR DESCRIPTION
Some plugins can update the `sendingZone` of a message:
https://github.com/zone-eu/zone-mta/tree/master/plugins#updating-database-entries

The update is not applied to metadata too (GFS stored).
On the next delivery attempt from the **NEW** `sendingZone`, the `delivery` object passed to plugins has the **OLD** `sendingZone`.
This update fixes this issue.