### PR TITLE
Add messageId to the entry object when using remote log

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -522,7 +522,8 @@ class Sender extends EventEmitter {
                                     response: bounces.formatSMTPResponse(info.response).substr(0, 312),
                                     size: messageStats.size,
                                     timer: messageStats.time,
-                                    start: messageStats.start
+                                    start: messageStats.start,
+                                    messageId: delivery.messageId || delivery.id
                                 });
 
                                 delivery.status = {
@@ -628,7 +629,8 @@ class Sender extends EventEmitter {
                 response: smtpResponse.substr(0, 312),
                 size: err.messageStats && err.messageStats.size,
                 timer: err.messageStats && err.messageStats.time,
-                start: err.messageStats && err.messageStats.start
+                start: err.messageStats && err.messageStats.start,
+                messageId: delivery.messageId || delivery.id
             });
 
             return this.deferDelivery(delivery, ttl, smtpLog, smtpResponse, bounce, (err, deferred) => {
@@ -670,7 +672,8 @@ class Sender extends EventEmitter {
                 response: smtpResponse.substr(0, 312),
                 size: err.messageStats && err.messageStats.size,
                 timer: err.messageStats && err.messageStats.time,
-                start: err.messageStats && err.messageStats.start
+                start: err.messageStats && err.messageStats.start,
+                messageId: delivery.messageId || delivery.id
             });
 
             delivery.status = {


### PR DESCRIPTION
This affects ACCEPTED, DEFERRED, and REJECTED logging updates from sender.js, and is useful when using log:entry to track the status of emails in plugins.