### PR TITLE
Handle suppression entries case-insensitive

### DIFF
--- a/lib/api-server.js
+++ b/lib/api-server.js
@@ -615,8 +615,8 @@ class APIServer {
         });
 
         this.server.post('/suppressionlist', (req, res, next) => {
-            let address = (req.params.address || '').trim();
-            let domain = (req.params.domain || '').trim();
+            let address = (req.params.address || '').trim().toLowerCase();
+            let domain = (req.params.domain || '').trim().toLowerCase();
 
             let entry = {
                 created: new Date()

--- a/lib/mail-queue.js
+++ b/lib/mail-queue.js
@@ -498,7 +498,7 @@ class MailQueue {
                                         address: (delivery.recipient || '').toLowerCase().trim()
                                     },
                                     {
-                                        domain: delivery.domain
+                                        domain: delivery.domain.toLowerCase().trim()
                                     }
                                 ]
                             },


### PR DESCRIPTION
Address entries in the suppression list are handled in lowercase at the
moment (mail-queue.js)

Ensure entries added via the api server are converted to lowercase.
Also ensure domain entries are handled in lowercase