### PR TITLE
Fix connection pooling with IPv6

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -829,7 +829,12 @@ class Sender extends EventEmitter {
             let startTime = Date.now();
 
             // create the connection cache key
-            delivery.connectionKey = delivery.connectionKey || [delivery.zoneAddress.address, this.zone.host || delivery.domain, delivery.mxPort].join(':');
+            // prefer IPv6 if wished
+            let zoneAddress = delivery.zoneAddress || delivery.zoneAddressIPv4;
+            if (this.zone.preferIPv6 && delivery.zoneAddressIPv6) {
+                zoneAddress = delivery.zoneAddressIPv6;
+            }
+            delivery.connectionKey = delivery.connectionKey || [zoneAddress.address, this.zone.host || delivery.domain, delivery.mxPort].join(':');
 
             // check if there is a connection with this key
             if (this.connectionPool.has(delivery.connectionKey)) {
@@ -844,7 +849,7 @@ class Sender extends EventEmitter {
                         conn.connection.id,
                         conn.connection.usageCount,
                         conn.connection.options.servername || conn.connection.options.host,
-                        delivery.zoneAddress.address
+                        zoneAddress.address
                     );
                     return callback(null, conn.connection);
                 }


### PR DESCRIPTION
The connection key was using `delivery.zoneAddress` which is only there if IPv6 is disabled.
Now it is using the correct zone addresses. 