### PR TITLE
Add sessionId to delivery object + handle delivery.isSuppressed flag

### DIFF
--- a/lib/mail-queue.js
+++ b/lib/mail-queue.js
@@ -315,7 +315,10 @@ class MailQueue {
                     queued: date,
 
                     // queued date might change but created should not
-                    created: date
+                    created: date,
+
+                    // add sessionId
+                    sessionId: envelope.sessionId
                 };
 
                 if (envelope.deferDelivery && envelope.deferDelivery > Date.now()) {
@@ -717,6 +720,7 @@ class MailQueue {
 
                         // no pending references, safe to remove the stored message
                         log.verbose('Queue', 'Deleting unreferenced message %s', delivery.id);
+                        log.info(`Sender/${delivery.sendingZone}/${process.pid} All SMTP sessions end id=${delivery.sessionId}`);
                         this.removeMessage(delivery.id, err => callback(null, !err));
                     }
                 );

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -150,6 +150,12 @@ class Sender extends EventEmitter {
                     return handleError(delivery, false, err);
                 }
 
+                if (delivery.isSuppressed === true) {
+                    return this.releaseDelivery(delivery, (err, released) => {
+                        return setTimeout(() => continueSending(), 1500).unref();
+                    });
+                }
+
                 this.zone.speedometer(this.ref, () => {
                     // check throttling speed
                     let connectTimer = setTimeout(() => {


### PR DESCRIPTION
This patch:

- adds the **sessionId** to the _delivery_ object.
- adds a log line to inform when all SMTP deliveries have done.
- adds the support of a new flag **delivery.isSuppressed** in case we want to use an external suppression engine and we don't want to delivery a specific message to a destination.