### PR TITLE
Add custom return path domain in delivery.account object

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1387,7 +1387,7 @@ class Sender extends EventEmitter {
                 headers: delivery.headers.getList(),
 
                 address: delivery.localAddress || (delivery.zoneAddress && delivery.zoneAddress.address),
-                name: delivery.localHostname || (delivery.zoneAddress && delivery.zoneAddress.name),
+                name: delivery.account.returnPathDomain || delivery.localHostname || (delivery.zoneAddress && delivery.zoneAddress.name),
                 mxHostname: delivery.mxHostname,
 
                 returnPath: delivery.from,

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1387,7 +1387,7 @@ class Sender extends EventEmitter {
                 headers: delivery.headers.getList(),
 
                 address: delivery.localAddress || (delivery.zoneAddress && delivery.zoneAddress.address),
-                name: delivery.account.returnPathDomain || delivery.localHostname || (delivery.zoneAddress && delivery.zoneAddress.name),
+                name: (delivery.account && delivery.account.returnPathDomain) || delivery.localHostname || (delivery.zoneAddress && delivery.zoneAddress.name),
                 mxHostname: delivery.mxHostname,
 
                 returnPath: delivery.from,


### PR DESCRIPTION
This patch:
- adds the support of a new flag delivery.account.returnPathDomain in case we want to use a custom return path domain, defined per user, and we don't want to use the default hostname or delivery zone name.