### PR TITLE
Retrieve ignoreTLS value from Sending Zone, or default to false

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -963,7 +963,7 @@ class Sender extends EventEmitter {
 
         let mxLastError = false;
         let ignoreMXHosts = [];
-        let ignoreTLS = false;
+        let ignoreTLS = !!this.zone.ignoreTLS || false;
 
         let tryConnect = () => {
             delivery.mxPort = delivery.mxPort || this.zone.port || 25;


### PR DESCRIPTION
Sending Zone class pulls ignoreTLS from config, but Sender did not use this value

Now it does