### PR TITLE
sender.js will on a tls failure try a delivery with out tls. However …

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1225,7 +1225,7 @@ class Sender extends EventEmitter {
 
                     if (
                         (err.code === 'ETLS' ||
-                            /SSL23_GET_SERVER_HELLO|\/deps\/openssl|ssl3_check|SSL routines/i.test(err.message) ||
+                            /SSL23_GET_SERVER_HELLO|\/deps\/openssl|ssl3_check|ssl3_get_record|SSL routines/i.test(err.message) ||
                             err.code === 'ECONNRESET') &&
                         !ignoreTLS &&
                         !enforceTLS


### PR DESCRIPTION
…on freebsd 13 a misconfigured server may show

35242434560:error:1408F10B:SSL routines:ssl3_get_record:wrong version number:/usr/src/crypto/openssl/ssl/record/ssl3_record.c:339: But this is not detected as a tls failure and the delivery does not succeed. sender.js has been updated for this error