### PR TITLE
Adding missing category "envelope"

### DIFF
--- a/config/bounces.txt
+++ b/config/bounces.txt
@@ -3,7 +3,7 @@
 #   regex,action,category,message
 # action: defer, reject, slowdown
 # categories:
-#   rate, block, spam, message, config, recipient, other, capacity, greylist, network, protocol, auth, blacklist
+#   rate, block, spam, message, config, recipient, other, capacity, greylist, network, protocol, auth, blacklist, envelope
 
 # This file will be cached after ZoneMTA is started, so in order to reload the rules, send a SIGHUP signal to the master process
 


### PR DESCRIPTION
There are several rules which refer to the category "envelope" but are not specified at the top of the list of categories that exist. I just added that category at the top so it's easy to refer to all possible categories that exist with ZoneMTA.