### PR TITLE
feat: add zone name to prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ The exposed metrics include a lot of different data but the most important ones 
 
 ##### zonemta_delivery_status
 
-`zonemta_delivery_status` exposes counters for delivery statuses. There are 3 different `result` label values
+`zonemta_delivery_status` exposes counters for delivery statuses. There are 3 different `result` label values. The zone name is exposed in the `zone` label.
 
 -   `result="delivered"` – count of deliveries accepted by remote MX
 -   `result="rejected"` – count of deliveries that hard bounced

--- a/lib/queue-server.js
+++ b/lib/queue-server.js
@@ -18,15 +18,17 @@ const deliveryStatusCounter = new promClient.Counter({
 const messagePushCounter = new promClient.Counter({
     name: 'zonemta_message_push',
     help: 'Messages pushed to queue',
-    labelNames: ['result']
+    labelNames: ['result', 'zone']
 });
 const bounceCounter = new promClient.Counter({
     name: 'zonemta_bounce_generation',
-    help: 'Bounce generation'
+    help: 'Bounce generation',
+    labelNames: ['zone']
 });
 const dropCounter = new promClient.Counter({
     name: 'zonemta_message_drop',
-    help: 'Messages dropped'
+    help: 'Messages dropped',
+    labelNames: ['zone']
 });
 
 const promMetrics = {
@@ -213,7 +215,9 @@ class QueueServer {
 
                     case 'BOUNCE':
                         {
-                            bounceCounter.inc();
+                            bounceCounter.inc({
+                                zone: client.zone.name
+                            });
                             const bounce = data;
                             bounce.headers = new Headers(bounce.headers || []);
                             plugins.handler.runHooks(
@@ -230,7 +234,9 @@ class QueueServer {
                         break;
 
                     case 'REMOVE':
-                        dropCounter.inc();
+                        dropCounter.inc({
+                            zone: client.zone.name
+                        });
                         this.queue.removeMessage(data.id, err => {
                             if (!client) {
                                 // client already errored or closed
@@ -290,7 +296,8 @@ class QueueServer {
                     case 'PUSH':
                         this.queue.push(data.id, data.envelope, err => {
                             messagePushCounter.inc({
-                                result: err ? 'fail' : 'success'
+                                result: err ? 'fail' : 'success',
+                                zone: client.zone.name
                             });
                             if (!client) {
                                 // client already errored or closed

--- a/lib/queue-server.js
+++ b/lib/queue-server.js
@@ -18,17 +18,15 @@ const deliveryStatusCounter = new promClient.Counter({
 const messagePushCounter = new promClient.Counter({
     name: 'zonemta_message_push',
     help: 'Messages pushed to queue',
-    labelNames: ['result', 'zone']
+    labelNames: ['result']
 });
 const bounceCounter = new promClient.Counter({
     name: 'zonemta_bounce_generation',
-    help: 'Bounce generation',
-    labelNames: ['zone']
+    help: 'Bounce generation'
 });
 const dropCounter = new promClient.Counter({
     name: 'zonemta_message_drop',
-    help: 'Messages dropped',
-    labelNames: ['zone']
+    help: 'Messages dropped'
 });
 
 const promMetrics = {
@@ -215,9 +213,7 @@ class QueueServer {
 
                     case 'BOUNCE':
                         {
-                            bounceCounter.inc({
-                                zone: client.zone.name
-                            });
+                            bounceCounter.inc();
                             const bounce = data;
                             bounce.headers = new Headers(bounce.headers || []);
                             plugins.handler.runHooks(
@@ -234,9 +230,7 @@ class QueueServer {
                         break;
 
                     case 'REMOVE':
-                        dropCounter.inc({
-                            zone: client.zone.name
-                        });
+                        dropCounter.inc();
                         this.queue.removeMessage(data.id, err => {
                             if (!client) {
                                 // client already errored or closed
@@ -296,8 +290,7 @@ class QueueServer {
                     case 'PUSH':
                         this.queue.push(data.id, data.envelope, err => {
                             messagePushCounter.inc({
-                                result: err ? 'fail' : 'success',
-                                zone: client.zone.name
+                                result: err ? 'fail' : 'success'
                             });
                             if (!client) {
                                 // client already errored or closed

--- a/lib/queue-server.js
+++ b/lib/queue-server.js
@@ -13,7 +13,7 @@ const promClient = require('prom-client');
 const deliveryStatusCounter = new promClient.Counter({
     name: 'zonemta_delivery_status',
     help: 'Delivery status',
-    labelNames: ['status']
+    labelNames: ['status', 'zone']
 });
 const messagePushCounter = new promClient.Counter({
     name: 'zonemta_message_push',
@@ -155,7 +155,8 @@ class QueueServer {
                             deliveryStatus = data.status.delivered ? 'delivered' : 'rejected';
                         }
                         deliveryStatusCounter.inc({
-                            status: deliveryStatus
+                            status: deliveryStatus,
+                            zone: client.zone.name
                         });
                         return this.releaseDelivery(client.zone, client.id, data, (err, response) => {
                             if (!client) {
@@ -188,7 +189,8 @@ class QueueServer {
                             });
                         }
                         deliveryStatusCounter.inc({
-                            status: 'deferred'
+                            status: 'deferred',
+                            zone: client.zone.name
                         });
 
                         return this.deferDelivery(client.zone, client.id, data, (err, response) => {


### PR DESCRIPTION
Hello,

I've added the zone-name to the `zonemta_delivery_status` metric. For the other counters, I've tried it, but did not succeeded in a timly manner. Please squash & merge if accepted.