### PR TITLE
ZMS-170

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -100,7 +100,7 @@ class Sender extends EventEmitter {
 
                 get: async domain => {
                     if (!db.redis) {
-                        return { enabled: false, error: 'Redis connection error' }; // if no redis return that MTA-STS is disabled
+                        return { enabled: false, error: { message: 'Redis connection error' } }; // if no redis return that MTA-STS is disabled
                     }
                     try {
                         let json = await db.redis.get(`sts:${domain}`);
@@ -123,7 +123,7 @@ class Sender extends EventEmitter {
                         }
                     } catch (err) {
                         log.error(this.logName + '/MTA-STS', 'Redis error domain=%s err=%s', domain, err.message);
-                        return { enabled: false, error: 'Redis request and connection error' }; // If redis error return MTA-STS is disabled
+                        return { enabled: false, error: { message: 'Redis request and connection error' } }; // If redis error return MTA-STS is disabled
                     }
                 }
             },

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -100,7 +100,7 @@ class Sender extends EventEmitter {
 
                 get: async domain => {
                     if (!db.redis) {
-                        return;
+                        return { enabled: false, error: 'Redis connection error' }; // if no redis return that MTA-STS is disabled
                     }
                     try {
                         let json = await db.redis.get(`sts:${domain}`);
@@ -123,6 +123,7 @@ class Sender extends EventEmitter {
                         }
                     } catch (err) {
                         log.error(this.logName + '/MTA-STS', 'Redis error domain=%s err=%s', domain, err.message);
+                        return { enabled: false, error: 'Redis request and connection error' }; // If redis error return MTA-STS is disabled
                     }
                 }
             },


### PR DESCRIPTION
In case of redis error return that MTA-STS is disabled. Currently messages will not be sent at all if there is a redis error during the fetch of MTA-STS cache. Now if there is an error it just returns that the MTA-STS is disabled