### PR TITLE
fix: honour per-zone blockLocalAddresses in delivery dnsOptions

### DIFF
--- a/lib/sending-zone.js
+++ b/lib/sending-zone.js
@@ -76,6 +76,7 @@ class SendingZone {
             'resolveIp',
             'ignoreIPv6',
             'preferIPv6',
+            'blockLocalAddresses',
             'port',
             'host',
             'auth',


### PR DESCRIPTION
Sender already reads blockLocalAddresses from the zone config (alongside preferIPv6/ignoreIPv6), but SendingZone.update() never copied it onto the zone instance, so a per-zone blockLocalAddresses was silently dropped and only the global config.dns value applied. Add it to the copied-property whitelist to match what sender.js expects.