### PR TITLE
fix: honor 5xx errors on greeting as reject

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -823,6 +823,16 @@ class Sender extends EventEmitter {
     handleResponseError(delivery, connection, err, callback) {
         let bounce;
 
+        if (!err.responseCode) {
+            // Recover the SMTP status code from the response text so every error path — not just
+            // the connection handler — has err.responseCode as the single source of truth. Left
+            // unset when there is no SMTP code (timeouts, socket errors) so those stay deferrable.
+            let parsed = Number((err.response || err.message || '').match(/^(\d{3})\b/)?.[1]);
+            if (parsed) {
+                err.responseCode = parsed;
+            }
+        }
+
         if (err.protocol === 'http') {
             // mail2http failures
             bounce = {
@@ -840,7 +850,7 @@ class Sender extends EventEmitter {
                 message: err.response || err.message,
                 status: false
             };
-        } else if (!err.responseCode && !/^\d{3}\b/.test(err.response || err.message)) {
+        } else if (!err.responseCode) {
             // timeouts, node network errors etc.
             bounce = {
                 action: 'defer',
@@ -1378,12 +1388,15 @@ class Sender extends EventEmitter {
                         }
                     }
 
-                    err.response = err.response || `Network error: Error connecting to ${mx.host}. ${err.message}`;
-                    err.category = err.category || 'network';
-                    err.logtrail = logtrail;
+                    // Permanent only on an explicit 5xx. A 4xx or a missing code (network/timeout)
+                    // stays deferrable — the >= 500 test is deliberate so an absent code
+                    // (undefined/NaN) is treated as deferrable, not mistaken for permanent.
                     if (typeof err.temporary !== 'boolean') {
-                        err.temporary = true;
+                        err.temporary = !(err.responseCode >= 500);
                     }
+                    err.category = err.category || (err.temporary ? 'network' : 'policy'); 
+                    err.response = err.response || `Network error: Error connecting to ${mx.host}. ${err.message}`;
+                    err.logtrail = logtrail;
 
                     let tlsAttempted = tlsRetry.isTlsAttempted(connection, options.secure);
 


### PR DESCRIPTION
Without this fix such emails would live in deferred queue which had to be rejected:
```
2026-07-13T12:03:45.149Z [INF]: Connection established to <IP>:25
2026-07-13T12:03:45.307Z [DBG]: 554 5.7.1 You are not allowed to connect.
2026-07-13T12:03:45.307Z [ERR]: Invalid greeting. response=554 5.7.1 You are not allowed to connect.: 554 5.7.1 You are not allowed to connect.
2026-07-13T12:03:45.307Z [DBG]: Closing connection to the server using "end"
```

RFC 5321 §4.2.1 — reply code theory is unambiguous:

5yz = Permanent Negative Completion. "The SMTP client SHOULD NOT repeat the exact request (in the same sequence)."
4yz = Transient Negative Completion. Retry later.

The class digit is the retry semantics. A 5xx is permanent by definition, regardless of protocol stage.

Catches:
1. state machine at connect level do not know yet anything about `bounces.txt` and as result "IP auto switch" logic doesn't work at this stage, to cover this up - separate piece of work is needed. I want to leave this PR minimalistic to provide correct behavior from protocol view.
2. none of existing `err.category` (`dns/network/policy`) fits fine into greeting error.