### PR TITLE
fix: classify connect-stage SMTP errors with bounce rules

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -823,16 +823,6 @@ class Sender extends EventEmitter {
     handleResponseError(delivery, connection, err, callback) {
         let bounce;
 
-        if (!err.responseCode) {
-            // Recover the SMTP status code from the response text so every error path — not just
-            // the connection handler — has err.responseCode as the single source of truth. Left
-            // unset when there is no SMTP code (timeouts, socket errors) so those stay deferrable.
-            let parsed = Number((err.response || err.message || '').match(/^(\d{3})\b/)?.[1]);
-            if (parsed) {
-                err.responseCode = parsed;
-            }
-        }
-
         if (err.protocol === 'http') {
             // mail2http failures
             bounce = {
@@ -843,14 +833,15 @@ class Sender extends EventEmitter {
                 status: false
             };
         } else if (['dns', 'network', 'policy'].includes(err.category)) {
-            // preset categories from mx-connect etc
+            // preset categories from mx-connect etc. _onError() depends on this list: it leaves
+            // permanent connect failures uncategorized so they reach bounces.check() below
             bounce = {
                 action: err.temporary || err.action === 'defer' ? 'defer' : 'reject',
                 category: err.category,
                 message: err.response || err.message,
                 status: false
             };
-        } else if (!err.responseCode) {
+        } else if (!err.responseCode && !/^\d{3}\b/.test(err.response || err.message)) {
             // timeouts, node network errors etc.
             bounce = {
                 action: 'defer',
@@ -1388,15 +1379,26 @@ class Sender extends EventEmitter {
                         }
                     }
 
-                    // Permanent only on an explicit 5xx. A 4xx or a missing code (network/timeout)
-                    // stays deferrable — the >= 500 test is deliberate so an absent code
-                    // (undefined/NaN) is treated as deferrable, not mistaken for permanent.
-                    if (typeof err.temporary !== 'boolean') {
-                        err.temporary = !(err.responseCode >= 500);
-                    }
-                    err.category = err.category || (err.temporary ? 'network' : 'policy'); 
                     err.response = err.response || `Network error: Error connecting to ${mx.host}. ${err.message}`;
                     err.logtrail = logtrail;
+
+                    if (typeof err.temporary !== 'boolean') {
+                        // An absent reply code (socket errors, timeouts) must stay deferrable, so test
+                        // for >= 500 rather than negating a 4xx test — undefined >= 500 is false.
+                        err.temporary = !(err.responseCode >= 500);
+                    }
+
+                    if (err.temporary) {
+                        // Keep transient failures away from bounces.txt: its 4xx rules answer for a
+                        // response to an envelope, where "452 over quota" is a final verdict. At
+                        // connect time it is not one, and RFC 5321 wants these retried.
+                        err.category = err.category || 'network';
+                    }
+                    // Permanent failures get no preset category on purpose — that is what routes them
+                    // to bounces.txt in handleResponseError() instead of the dns/network/policy branch.
+                    // Those rules end in "^5\d\d,reject,other" so an unrecognized 5xx still rejects,
+                    // while the specific rules above it apply, including the blacklist ones that
+                    // rotate the source IP for a domain.
 
                     let tlsAttempted = tlsRetry.isTlsAttempted(connection, options.secure);
 

--- a/test/bounces-test.js
+++ b/test/bounces-test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const bounces = require('../lib/bounces');
+
+module.exports['Defer and blacklist a rejection that names the sender IP'] = test => {
+    let bounce = bounces.check('554 5.7.1 You are not allowed to connect.');
+    test.equal(bounce.action, 'defer');
+    test.equal(bounce.category, 'blacklist');
+    test.equal(bounce.code, 554);
+    test.done();
+};
+
+module.exports['Reject an unrecognized permanent response'] = test => {
+    let bounce = bounces.check('599 zzqq totally unknown gibberish');
+    test.equal(bounce.action, 'reject');
+    test.equal(bounce.category, 'other');
+    test.equal(bounce.code, 599);
+    test.done();
+};
+
+module.exports['Defer an unrecognized transient response'] = test => {
+    let bounce = bounces.check('499 zzqq totally unknown gibberish');
+    test.equal(bounce.action, 'defer');
+    test.equal(bounce.category, 'other');
+    test.equal(bounce.code, 499);
+    test.done();
+};
+
+module.exports['Keep the caller category when there is no response to classify'] = test => {
+    let bounce = bounces.check('', 'network');
+    test.equal(bounce.action, 'reject');
+    test.equal(bounce.category, 'network');
+    test.done();
+};


### PR DESCRIPTION
Follow-up to #496, which correctly diagnosed a real bug but fixed it one layer too high.

### The problem

`_onError` preset `err.category = 'network'` on every connect-stage failure. `handleResponseError` short-circuits on a `dns`/`network`/`policy` category, so **`bounces.check()` has never run for connect-stage errors** — the whole ruleset has been dead there, including the rule that names the exact response from #496 verbatim:

```
# 554 5.7.1 You are not allowed to connect
^554[ \-].* You are not allowed to connect,defer,blacklist,Sender IP blacklisted
```

That also explains both of the "catches" in #496: no `err.category` fitted because the category was never supposed to be chosen in code, and the IP auto-switch "didn't work at this stage" because `category: 'blacklist'` is exactly what drives it.

### The fix

Leave permanent (5xx) connect failures uncategorized so the rules classify them. `config/bounces.txt` already ends in:

```
^4\d\d,defer,other,Other temporary error
^5\d\d,reject,other,Other permanent error
```

so an unrecognized 5xx still rejects per RFC 5321 §4.2.1 — #496's goal, kept — without hardcoding that policy in JS, while the 85 blacklist rules above it apply and rotate the source IP via `disabledAddresses`.

Transient failures keep `category: 'network'` and defer as before. That boundary is deliberate: the 4xx rules answer for a response to an envelope, where `452 over quota` is final. At connect time it isn't, and 7 of 8 realistic greeting-stage 4xx responses would flip action if routed through them.

Net effect at greeting:

| response | before | after |
|---|---|---|
| `554 ... You are not allowed to connect` | defer ×17 over 48h on the same IP, then bounce | defer + blacklist that IP for the domain → next attempt uses another pool IP → reject once the pool is exhausted |
| 5xx matching no specific rule | same dead-end deferral | reject (rule 571) |
| 4xx / socket error / timeout | defer | unchanged |

Also reverts #496's `handleResponseError` hunk: nodemailer already sets `err.responseCode` in `_formatError` before `_onError` runs, nothing downstream read the backfilled value, and the rewritten condition was equivalent to the original. The net production diff vs 3.10.17 is one hunk in `_onError`.

### Verified

- Drove the real `handleResponseError`: `554 ... not allowed to connect` → `DEFERRED[blacklist]` with `category: blacklist` + `address` set, passing the `sending-zone.js:350` guard → IP rotates. Unrecognized 5xx → `REJECTED[other]`. `421` → `DEFERRED[network]`.
- Drove a fake MX over a real socket to confirm nodemailer populates `err.responseCode`/`err.response` from the banner before `_onError` sees it.
- New `test/bounces-test.js` (first coverage for `bounces.check`) pins the three rules this routing depends on. Suite + eslint green.

### Notes

- Blast radius is wider than the greeting: `_onError` also covers HELO/LHLO, EHLO-with-requireTLS and STARTTLS, so a 5xx there routes through the rules too. Consistent with the intent.
- Under `enforceTLS` the banner arrives before STARTTLS, so an on-path attacker can inject a 5xx that blacklists a pool IP for that domain for `blacklist.ttl`, where before it became `policy`/reject. Bounded and per-domain (`DomainConfig.get` deep-clones, so shared defaults can't be poisoned), and such an attacker can already fail the delivery outright — noting it so the tradeoff is deliberate.

Thanks @dragoangel for the diagnosis and the production trace — the bug and its cause were both yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFF2LP1xQR2yV9DB37wPyD
