### PR TITLE
feat: bump mx-connect to 1.7.0, add new blockReservedNetworks option

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -283,7 +283,11 @@ module.exports = {
         nameservers: false,
 
         // If true, then do not allow sending to MX servers in localhost or private IP range
-        blockLocalAddresses: false
+        blockLocalAddresses: false,
+
+        // If true, then do not allow sending to MX servers in multicast, future-use or
+        // documentation ranges
+        blockReservedNetworks: false
     },
 
     mtaSts: {

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -233,7 +233,7 @@ class Sender extends EventEmitter {
                 to: delivery.recipient
             };
 
-            ['preferIPv6', 'ignoreIPv6', 'blockLocalAddresses'].forEach(key => {
+            ['preferIPv6', 'ignoreIPv6', 'blockLocalAddresses', 'blockReservedNetworks'].forEach(key => {
                 if (key in delivery.dnsOptions) {
                     return;
                 }

--- a/lib/sending-zone.js
+++ b/lib/sending-zone.js
@@ -77,6 +77,7 @@ class SendingZone {
             'ignoreIPv6',
             'preferIPv6',
             'blockLocalAddresses',
+            'blockReservedNetworks',
             'port',
             'host',
             'auth',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "minimist": "1.2.8",
                 "mongodb": "4.17.2",
                 "msgpack-js": "0.3.0",
-                "mx-connect": "1.6.0",
+                "mx-connect": "1.7.0",
                 "nodemailer": "9.0.3",
                 "npmlog": "7.0.1",
                 "prom-client": "15.1.3",
@@ -4188,10 +4188,9 @@
             }
         },
         "node_modules/ipaddr.js": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
-            "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
-            "license": "MIT",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+            "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
             "engines": {
                 "node": ">= 10"
             }
@@ -4570,24 +4569,6 @@
             "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/joi": {
-            "version": "18.0.2",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-            "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@hapi/address": "^5.1.1",
-                "@hapi/formula": "^3.0.2",
-                "@hapi/hoek": "^11.0.7",
-                "@hapi/pinpoint": "^2.0.1",
-                "@hapi/tlds": "^1.1.1",
-                "@hapi/topo": "^6.0.2",
-                "@standard-schema/spec": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -4970,15 +4951,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/mailauth/node_modules/ipaddr.js": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
-            "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/mailauth/node_modules/joi": {
             "version": "18.2.1",
             "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
@@ -5349,200 +5321,16 @@
             }
         },
         "node_modules/mx-connect": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mx-connect/-/mx-connect-1.6.0.tgz",
-            "integrity": "sha512-mSMQivbytvHKu8jPW6p+h314PkbdBCGH1vQIrpFpP2pr2JhWIpMRBCRumjA0tMeNjT0Emh7w32aD05WMoKtqrA==",
-            "license": "EUPL-1.1+",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/mx-connect/-/mx-connect-1.7.0.tgz",
+            "integrity": "sha512-F0g6pC0NS1UepCLVl7p1Rvwnne7itUiH2D4eoGPVS+9D3N1hUvCW0sxN9dFe2KdQ//Pf8WHyy/HO1zY/FAtONw==",
             "dependencies": {
-                "ipaddr.js": "2.3.0",
-                "mailauth": "4.13.0",
+                "ipaddr.js": "2.4.0",
+                "mailauth": "4.13.3",
                 "punycode": "^2.3.1"
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/mx-connect/node_modules/@peculiar/asn1-schema": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-            "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
-            "license": "MIT",
-            "dependencies": {
-                "asn1js": "^3.0.6",
-                "pvtsutils": "^1.3.6",
-                "tslib": "^2.8.1"
-            }
-        },
-        "node_modules/mx-connect/node_modules/@peculiar/asn1-x509": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
-            "integrity": "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==",
-            "license": "MIT",
-            "dependencies": {
-                "@peculiar/asn1-schema": "^2.6.0",
-                "asn1js": "^3.0.6",
-                "pvtsutils": "^1.3.6",
-                "tslib": "^2.8.1"
-            }
-        },
-        "node_modules/mx-connect/node_modules/@peculiar/asn1-x509-logotype": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-logotype/-/asn1-x509-logotype-2.6.0.tgz",
-            "integrity": "sha512-9wWbG1JkOLV3yMwt93Q2z5HQM5VQbYO9J17Wr9NatMlObLAxKAwhYhG/FgYqEnPwBZCdOf6AOToW9c6SltZmPw==",
-            "license": "MIT",
-            "dependencies": {
-                "@peculiar/asn1-schema": "^2.6.0",
-                "@peculiar/asn1-x509": "^2.6.0",
-                "asn1js": "^3.0.6",
-                "tslib": "^2.8.1"
-            }
-        },
-        "node_modules/mx-connect/node_modules/@postalsys/vmc": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@postalsys/vmc/-/vmc-1.1.3.tgz",
-            "integrity": "sha512-oBmAYvc5Wqwf8T6Amlwx45C0Jq9hNKprKqO1y+2f2PKBQ7NrG6KkyrSdVDPT/OOk/s8qCVFt+H/Ry9ldV74Rvw==",
-            "license": "MIT",
-            "dependencies": {
-                "@peculiar/asn1-schema": "2.6.0",
-                "@peculiar/asn1-x509": "2.6.0",
-                "@peculiar/asn1-x509-logotype": "2.6.0"
-            }
-        },
-        "node_modules/mx-connect/node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/mx-connect/node_modules/fast-xml-parser": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-            "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "strnum": "^2.1.0"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
-            }
-        },
-        "node_modules/mx-connect/node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/mx-connect/node_modules/libmime": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
-            "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
-            "license": "MIT",
-            "dependencies": {
-                "encoding-japanese": "2.2.0",
-                "iconv-lite": "0.6.3",
-                "libbase64": "1.3.0",
-                "libqp": "2.1.1"
-            }
-        },
-        "node_modules/mx-connect/node_modules/mailauth": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/mailauth/-/mailauth-4.13.0.tgz",
-            "integrity": "sha512-fLnDxb1m9hVmGjNsPE0FwuwV/UgxXYgJP9/Y78xSH5ara5zE4HmOJ2wWOpgmfp4JYpVFdPa0qutJ4bDHdm0aXw==",
-            "license": "MIT",
-            "dependencies": {
-                "@postalsys/vmc": "1.1.3",
-                "fast-xml-parser": "5.3.4",
-                "ipaddr.js": "2.3.0",
-                "joi": "18.0.2",
-                "libmime": "5.3.7",
-                "nodemailer": "7.0.13",
-                "punycode.js": "2.3.1",
-                "tldts": "7.0.21",
-                "undici": "7.20.0",
-                "yargs": "17.7.2"
-            },
-            "bin": {
-                "mailauth": "bin/mailauth.js"
-            },
-            "engines": {
-                "node": ">=20.18.1"
-            }
-        },
-        "node_modules/mx-connect/node_modules/nodemailer": {
-            "version": "7.0.13",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-            "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
-            "license": "MIT-0",
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/mx-connect/node_modules/tldts": {
-            "version": "7.0.21",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.21.tgz",
-            "integrity": "sha512-Plu6V8fF/XU6d2k8jPtlQf5F4Xx2hAin4r2C2ca7wR8NK5MbRTo9huLUWRe28f3Uk8bYZfg74tit/dSjc18xnw==",
-            "license": "MIT",
-            "dependencies": {
-                "tldts-core": "^7.0.21"
-            },
-            "bin": {
-                "tldts": "bin/cli.js"
-            }
-        },
-        "node_modules/mx-connect/node_modules/undici": {
-            "version": "7.20.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.20.0.tgz",
-            "integrity": "sha512-MJZrkjyd7DeC+uPZh+5/YaMDxFiiEEaDgbUSVMXayofAkDWF1088CDo+2RPg7B1BuS1qf1vgNE7xqwPxE0DuSQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=20.18.1"
-            }
-        },
-        "node_modules/mx-connect/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/mx-connect/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/nan": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "minimist": "1.2.8",
         "mongodb": "4.17.2",
         "msgpack-js": "0.3.0",
-        "mx-connect": "1.6.0",
+        "mx-connect": "1.7.0",
         "nodemailer": "9.0.3",
         "npmlog": "7.0.1",
         "prom-client": "15.1.3",


### PR DESCRIPTION
Bumps `mx-connect` to 1.7.0 and exposes the `blockReservedNetworks` switch it introduces.

## What 1.7.0 brings

Hardened MX IP validation, null MX rejection (RFC 7505), TLSA lookups skipped for non-DNSSEC zones (RFC 7672), and a fix for `extractSPKI()` returning the raw public key instead of SPKI DER.

MX destinations are now classified in three tiers:

| Tier | Ranges | Switch |
|---|---|---|
| Never valid | `unspecified` (0.0.0.0), `broadcast`, `multicast` | none — always rejected |
| Local scope | loopback, private, link-local, CGNAT, unique-local | `blockLocalAddresses` |
| Reserved | future-use 240.0.0.0/4, RFC 5737 / RFC 3849 documentation | `blockReservedNetworks` (new) |

## What this PR adds

Only the second tier was reachable from zone-mta. `blockReservedNetworks` is now wired identically:

- `config/default.js` — global `dns.blockReservedNetworks: false`
- `lib/sending-zone.js` — copied onto the zone like the other delivery options
- `lib/sender.js` — folded into `delivery.dnsOptions`

Precedence matches `blockLocalAddresses`: per-delivery `dnsOptions` → zone → `config.dns`. Defaults to `false`, same as mx-connect.

## Behaviour change

The first tier arrives with the bump and has no opt-out: an MX resolving to `0.0.0.0`, `255.255.255.255` or a multicast address is now rejected regardless of configuration. Nothing else changes for existing deployments.

## About the lockfile

`package-lock.json` loses 221 lines — 16 entries removed, none added. That is the effect of the bump, not collateral damage:

- 14 of them are the entire `node_modules/mx-connect/node_modules/*` subtree. 1.6.0 pinned `mailauth@4.13.0` while zone-mta pins `4.13.3`, so npm kept a private copy along with its full transitive tree. 1.7.0 pins `4.13.3`, so it dedupes into the hoisted one.
- `node_modules/mailauth/node_modules/ipaddr.js` — the hoisted `ipaddr.js` was 2.3.0 (1.6.0's pin), so mailauth carried its own 2.4.0. The hoisted one is now 2.4.0 itself.
- `node_modules/joi` — hoisted only for the nested `mailauth@4.13.0`. The `joi` that `mailauth@4.13.3` needs lives at `node_modules/mailauth/node_modules/joi` and is untouched in both locks.

Checked by walking every remaining package's declared dependencies in npm's resolution order: no unresolved dependency in the resulting tree, and nothing added.

The node floor is unaffected: the strictest requirement in the tree is `mailauth`'s `node >=20.18.1`, which zone-mta already depends on directly and which is unchanged here. The bump only drops the two nested copies (`mx-connect/mailauth`, `mx-connect/undici`) that carried the same requirement.

## Verification

Run in a clean `node:20` container (node 20.20.2, npm 10.8.2):

- `npm ci` — installs cleanly, 651 packages, so the lockfile is consistent with `package.json`.
- `npm test` (grunt: eslint + nodeunit) — lint clean, 227 assertions passed.
- `npm install --package-lock-only` reproduces the committed lockfile byte for byte. The committed file was generated by npm 9 on node 18, so both toolchains resolve the tree identically — the dedupe above is npm's own resolution, not an artifact of the environment it was generated in.
