### PR TITLE
fix logging when logger is false and 4xx or 5xx smtp errors occur

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -251,7 +251,8 @@ module.exports = {
             // (you do need to increase the allowed memory for the v8 when using huge recipient lists)
             maxRecipients: 1000,
 
-            // set to true to see incoming SMTP transaction log
+            // set to true to see the full SMTP transaction log (including AUTH payloads)
+            // 4xx/5xx responses are always logged at info without raw client commands
             logger: false,
 
             starttls: false, // set to true to enable STARTTLS (port 587)

--- a/config/default.js
+++ b/config/default.js
@@ -252,7 +252,7 @@ module.exports = {
             maxRecipients: 1000,
 
             // set to true to see the full SMTP transaction log (including AUTH payloads)
-            // 4xx/5xx responses are always logged at info without raw client commands
+            // 4xx/5xx responses sent by the SMTP server are logged at info regardless of this setting
             logger: false,
 
             starttls: false, // set to true to enable STARTTLS (port 587)

--- a/lib/log-smtp.js
+++ b/lib/log-smtp.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const log = require('npmlog');
+
+// Connections that are refused before they reach an SMTP server never pass through
+// smtp-server's logger, so the SMTPRESPONSE line in lib/smtp-interface.js does not cover
+// them. Both the master proxy and the receiver worker record them through here so the two
+// processes emit the same line for log parsers to consume.
+const logSmtpReject = (logName, socket, message) => {
+    log.info(logName, 'SMTPREJECT src=%s response=%s', (socket && socket.remoteAddress) || '', JSON.stringify(message));
+};
+
+module.exports = { logSmtpReject };

--- a/lib/receiver/smtp-proxy.js
+++ b/lib/receiver/smtp-proxy.js
@@ -12,10 +12,12 @@ const plugins = require('../plugins');
 const tlsOptions = require('smtp-server/lib/tls-options');
 const childShutdown = require('../child-shutdown');
 const { gelfCode, emitGelf } = require('../log-gelf');
+const { logSmtpReject } = require('../log-smtp');
 
 class SMTPProxy {
     constructor(smtpInterface, options) {
         this.name = smtpInterface;
+        this.logName = 'SMTP/' + smtpInterface + '/' + process.pid;
         this.options = options || {};
         this.children = new Set();
         this.processes = this.options.processes || 1;
@@ -82,6 +84,10 @@ class SMTPProxy {
     }
 
     socketEnd(socket, message) {
+        // The connection is refused before it ever reaches an SMTP server, so nothing else
+        // records it
+        logSmtpReject(this.logName, socket, message);
+
         let writeToSocket = () => {
             try {
                 socket.end(message + '\r\n');

--- a/lib/smtp-interface.js
+++ b/lib/smtp-interface.js
@@ -43,6 +43,64 @@ class SMTPInterface {
         this.queue = false;
     }
 
+    _createSMTPLogger() {
+        let commands = new Map();
+        let authenticating = new Set();
+
+        let quote = value => JSON.stringify(value === undefined || value === null || value === false ? '' : value.toString());
+
+        return nodemailerLogger.create((level, meta, ...args) => {
+            meta = meta || {};
+
+            let connectionId = meta.cid;
+            let hasConnectionId = connectionId !== undefined && connectionId !== null;
+
+            if (meta.tnx === 'command' && hasConnectionId && !authenticating.has(connectionId)) {
+                // Only retain smtp-server's parsed verb. The raw command can contain
+                // credentials, most notably the base64 payload used by AUTH.
+                commands.set(connectionId, meta.command || '');
+            }
+
+            if (meta.tnx === 'send' && hasConnectionId && args.length > 1) {
+                let response = (args[1] || '').toString();
+                let statusMatch = response.match(/^([0-9]{3})(?:[ -]|$)/);
+                let statusCode = statusMatch ? Number(statusMatch[1]) : false;
+
+                if (statusCode >= 400 && statusCode <= 599) {
+                    log.info(
+                        this.logName,
+                        'SMTPRESPONSE id=%s user=%s command=%s response=%s',
+                        quote(connectionId),
+                        quote(meta.user),
+                        quote(commands.get(connectionId)),
+                        quote(response)
+                    );
+                }
+
+                if (statusCode === 334) {
+                    // Authentication continuations are passed through smtp-server's
+                    // command parser. Keep AUTH as the command instead of recording
+                    // the base64 username or password that follows the challenge.
+                    authenticating.add(connectionId);
+                } else if (statusCode !== 354) {
+                    // 354 continues the DATA command; every other non-AUTH response
+                    // completes the current command. Clearing it also keeps an idle
+                    // timeout or shutdown response from being attributed to an old
+                    // command.
+                    authenticating.delete(connectionId);
+                    commands.delete(connectionId);
+                }
+            } else if (meta.tnx === 'close' && hasConnectionId) {
+                authenticating.delete(connectionId);
+                commands.delete(connectionId);
+            }
+
+            if (this.options.logger) {
+                log[NODEMAILER_LOG_LEVELS[level] || 'verbose'](this.options.name, ...args);
+            }
+        });
+    }
+
     setup(callback) {
         // Setup server
 
@@ -144,13 +202,11 @@ class SMTPInterface {
 
         getQueue(() => {
             getKeyfiles(() => {
-                let defaultLogger = nodemailerLogger.create((level, ...args) => {
-                    log[NODEMAILER_LOG_LEVELS[level] || 'verbose'](this.options.name, ...args.slice(1));
-                });
+                let smtpLogger = this._createSMTPLogger();
 
                 let serverConfig = {
                     // log to console
-                    logger: this.options.logger ? defaultLogger : false,
+                    logger: this.options.logger ? smtpLogger : false,
 
                     name: this.options.hostname || os.hostname(),
 
@@ -382,6 +438,14 @@ class SMTPInterface {
                 };
 
                 this.server = new SMTPServer(serverConfig);
+
+                if (!this.options.logger) {
+                    // smtp-server emits internally generated responses only through
+                    // its logger. Keep the constructor's logger:false behavior, then
+                    // install the filtered logger so 4xx/5xx responses are audited
+                    // without enabling the credential-bearing transcript.
+                    this.server.logger = smtpLogger;
+                }
 
                 this.server.on('error', err => {
                     log.error(this.logName, 'SERVERR error=%s debug=%s', err.message, JSON.stringify(err));

--- a/lib/smtp-interface.js
+++ b/lib/smtp-interface.js
@@ -14,6 +14,33 @@ const RemoteQueue = require('./remote-queue');
 const { gelfCode, emitGelf } = require('./log-gelf');
 const nodemailerLogger = require('./nodemailer-logger');
 
+// Commands that may be echoed into the rejection log. smtp-server derives meta.command from the
+// first token of the raw client input, so any token outside this set is unvalidated client data
+// of arbitrary length and must not reach the log.
+const LOGGED_SMTP_COMMANDS = new Set([
+    'AUTH',
+    'BDAT',
+    'DATA',
+    'EHLO',
+    'ETRN',
+    'EXPN',
+    'HELO',
+    'HELP',
+    'KILL',
+    'LHLO',
+    'MAIL',
+    'NOOP',
+    'QUIT',
+    'RCPT',
+    'RSET',
+    'SHELL',
+    'STARTTLS',
+    'VRFY',
+    'WIZ',
+    'XCLIENT',
+    'XFORWARD'
+]);
+
 const NODEMAILER_LOG_LEVELS = {
     trace: 'silly',
     debug: 'silly',
@@ -45,7 +72,6 @@ class SMTPInterface {
 
     _createSMTPLogger() {
         let commands = new Map();
-        let authenticating = new Set();
 
         let quote = value => JSON.stringify(value === undefined || value === null || value === false ? '' : value.toString());
 
@@ -53,46 +79,50 @@ class SMTPInterface {
             meta = meta || {};
 
             let connectionId = meta.cid;
-            let hasConnectionId = connectionId !== undefined && connectionId !== null;
 
-            if (meta.tnx === 'command' && hasConnectionId && !authenticating.has(connectionId)) {
-                // Only retain smtp-server's parsed verb. The raw command can contain
-                // credentials, most notably the base64 payload used by AUTH.
-                commands.set(connectionId, meta.command || '');
-            }
+            if (connectionId !== undefined && connectionId !== null) {
+                switch (meta.tnx) {
+                    case 'command':
+                        if (LOGGED_SMTP_COMMANDS.has(meta.command)) {
+                            commands.set(connectionId, meta.command);
+                        } else if (commands.get(connectionId) !== 'AUTH') {
+                            // meta.command is the uppercased first token of whatever the client sent,
+                            // so anything outside the known verbs is raw client input and must never
+                            // be logged. An AUTH exchange is kept as the current command instead, as
+                            // its continuation lines carry the base64 username and password.
+                            commands.set(connectionId, '');
+                        }
+                        break;
 
-            if (meta.tnx === 'send' && hasConnectionId && args.length > 1) {
-                let response = (args[1] || '').toString();
-                let statusMatch = response.match(/^([0-9]{3})(?:[ -]|$)/);
-                let statusCode = statusMatch ? Number(statusMatch[1]) : false;
+                    case 'send': {
+                        let response = (args[1] || '').toString();
+                        let statusMatch = response.match(/^([0-9]{3})(?:[ -]|$)/);
+                        let statusCode = statusMatch ? Number(statusMatch[1]) : false;
 
-                if (statusCode >= 400 && statusCode <= 599) {
-                    log.info(
-                        this.logName,
-                        'SMTPRESPONSE id=%s user=%s command=%s response=%s',
-                        quote(connectionId),
-                        quote(meta.user),
-                        quote(commands.get(connectionId)),
-                        quote(response)
-                    );
+                        if (statusCode >= 400 && statusCode <= 599) {
+                            log.info(
+                                this.logName,
+                                'SMTPRESPONSE id=%s user=%s command=%s response=%s',
+                                connectionId,
+                                quote(meta.user),
+                                quote(commands.get(connectionId)),
+                                quote(response)
+                            );
+                        }
+
+                        if (statusCode !== 334 && statusCode !== 354) {
+                            // 334 continues an AUTH exchange and 354 continues DATA, every other
+                            // response completes the current command. Clearing it also keeps an idle
+                            // timeout or shutdown response from being attributed to an old command.
+                            commands.delete(connectionId);
+                        }
+                        break;
+                    }
+
+                    case 'close':
+                        commands.delete(connectionId);
+                        break;
                 }
-
-                if (statusCode === 334) {
-                    // Authentication continuations are passed through smtp-server's
-                    // command parser. Keep AUTH as the command instead of recording
-                    // the base64 username or password that follows the challenge.
-                    authenticating.add(connectionId);
-                } else if (statusCode !== 354) {
-                    // 354 continues the DATA command; every other non-AUTH response
-                    // completes the current command. Clearing it also keeps an idle
-                    // timeout or shutdown response from being attributed to an old
-                    // command.
-                    authenticating.delete(connectionId);
-                    commands.delete(connectionId);
-                }
-            } else if (meta.tnx === 'close' && hasConnectionId) {
-                authenticating.delete(connectionId);
-                commands.delete(connectionId);
             }
 
             if (this.options.logger) {
@@ -205,8 +235,9 @@ class SMTPInterface {
                 let smtpLogger = this._createSMTPLogger();
 
                 let serverConfig = {
-                    // log to console
-                    logger: this.options.logger ? smtpLogger : false,
+                    // Always installed. The handler audits 4xx/5xx responses on its own and only
+                    // emits the full transcript when this.options.logger is set.
+                    logger: smtpLogger,
 
                     name: this.options.hostname || os.hostname(),
 
@@ -438,14 +469,6 @@ class SMTPInterface {
                 };
 
                 this.server = new SMTPServer(serverConfig);
-
-                if (!this.options.logger) {
-                    // smtp-server emits internally generated responses only through
-                    // its logger. Keep the constructor's logger:false behavior, then
-                    // install the filtered logger so 4xx/5xx responses are audited
-                    // without enabling the credential-bearing transcript.
-                    this.server.logger = smtpLogger;
-                }
 
                 this.server.on('error', err => {
                     log.error(this.logName, 'SERVERR error=%s debug=%s', err.message, JSON.stringify(err));

--- a/services/receiver.js
+++ b/services/receiver.js
@@ -7,6 +7,7 @@ const config = require('@zone-eu/wild-config');
 const log = require('npmlog');
 const crypto = require('crypto');
 const { gelfCode, emitGelf } = require('../lib/log-gelf');
+const { logSmtpReject } = require('../lib/log-smtp');
 require('../lib/log-setup')(config);
 
 log.level = config.log.level;
@@ -22,6 +23,7 @@ const queueClient = new QueueClient(config.queueServer);
 const RemoteQueue = require('../lib/remote-queue');
 
 let currentInterface = argv.interfaceName;
+let logName = 'SMTP/' + currentInterface + '/' + process.pid;
 let clientId = argv.interfaceId || crypto.randomBytes(10).toString('hex');
 let smtpServer = false;
 let pendingSockets = new Set();
@@ -33,6 +35,11 @@ let closeSocket = (socket, message) => {
     if (!socket) {
         return;
     }
+
+    // The socket never reaches the SMTP server, so nothing else records the refusal. A secure
+    // interface can not answer in plaintext and resets below, the refusal is logged either way.
+    logSmtpReject(logName, socket, message);
+
     if (config.smtpInterfaces[currentInterface] && config.smtpInterfaces[currentInterface].secure) {
         // the client is waiting for a TLS handshake and would not understand a plaintext
         // response, and upgrading just to say goodbye is not worth it

--- a/test/fixtures/capture-logs.js
+++ b/test/fixtures/capture-logs.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const util = require('util');
+const log = require('npmlog');
+
+const CAPTURED_LEVELS = ['silly', 'verbose', 'info', 'warn', 'error'];
+
+// Captures every npmlog level the SMTP code can route to, so output that ends up on an
+// unexpected level fails the assertions instead of leaking to the console
+module.exports = function captureLogs(callback) {
+    let originals = new Map();
+    let entries = [];
+
+    CAPTURED_LEVELS.forEach(level => {
+        originals.set(level, log[level]);
+        log[level] = (...args) => entries.push({ level, prefix: args[0], message: util.format(...args.slice(1)) });
+    });
+
+    try {
+        return callback(entries);
+    } finally {
+        originals.forEach((original, level) => {
+            log[level] = original;
+        });
+    }
+};

--- a/test/smtp-interface-test.js
+++ b/test/smtp-interface-test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const util = require('util');
+const log = require('npmlog');
+const SMTPInterface = require('../lib/smtp-interface');
+const plugins = require('../lib/plugins');
+
+function captureLogs(callback) {
+    let originalInfo = log.info;
+    let originalSilly = log.silly;
+    let entries = [];
+
+    log.info = (...args) => entries.push({ level: 'info', prefix: args[0], message: util.format(...args.slice(1)) });
+    log.silly = (...args) => entries.push({ level: 'silly', prefix: args[0], message: util.format(...args.slice(1)) });
+
+    try {
+        return callback(entries);
+    } finally {
+        log.info = originalInfo;
+        log.silly = originalSilly;
+    }
+}
+
+function createLogger(loggerEnabled) {
+    let smtpInterface = new SMTPInterface('feeder', { name: 'feeder', logger: loggerEnabled }, false);
+    return { smtpInterface, logger: smtpInterface._createSMTPLogger() };
+}
+
+module.exports['SMTP logger records rejected responses when the transcript is disabled'] = test => {
+    captureLogs(entries => {
+        let { smtpInterface, logger } = createLogger(false);
+
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'BDAT' }, 'C:', 'BDAT 100');
+        logger.debug({ tnx: 'send', cid: 'test-connection', user: 'sender@example.com' }, 'S:', '500 Error: command not recognized');
+
+        test.deepEqual(entries, [
+            {
+                level: 'info',
+                prefix: smtpInterface.logName,
+                message:
+                    'SMTPRESPONSE id="test-connection" user="sender@example.com" command="BDAT" response="500 Error: command not recognized"'
+            }
+        ]);
+    });
+    test.done();
+};
+
+module.exports['SMTP logger ignores successful responses when the transcript is disabled'] = test => {
+    captureLogs(entries => {
+        let { logger } = createLogger(false);
+
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'NOOP' }, 'C:', 'NOOP');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '250 OK');
+
+        test.deepEqual(entries, []);
+    });
+    test.done();
+};
+
+module.exports['SMTP logger records temporary failures without attributing a completed command'] = test => {
+    captureLogs(entries => {
+        let { logger } = createLogger(false);
+
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'NOOP' }, 'C:', 'NOOP');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '250 OK');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '421 Timeout - closing connection');
+
+        test.equal(entries.length, 1);
+        test.ok(/command=""/.test(entries[0].message));
+        test.ok(/response="421 Timeout - closing connection"/.test(entries[0].message));
+    });
+    test.done();
+};
+
+module.exports['SMTP logger never records AUTH continuation payloads in rejection logs'] = test => {
+    captureLogs(entries => {
+        let { logger } = createLogger(false);
+
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'AUTH' }, 'C:', 'AUTH LOGIN');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '334 VXNlcm5hbWU6');
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'dXNlckBleGFtcGxlLmNvbQ==' }, 'C:', 'dXNlckBleGFtcGxlLmNvbQ==');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '334 UGFzc3dvcmQ6');
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'c2VjcmV0' }, 'C:', 'c2VjcmV0');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '535 Error: Authentication credentials invalid');
+
+        test.equal(entries.length, 1);
+        test.ok(/command="AUTH"/.test(entries[0].message));
+        test.ok(!/dXNlckBleGFtcGxlLmNvbQ==/.test(entries[0].message));
+        test.ok(!/c2VjcmV0/.test(entries[0].message));
+    });
+    test.done();
+};
+
+module.exports['SMTP logger preserves the optional full transcript'] = test => {
+    captureLogs(entries => {
+        let { smtpInterface, logger } = createLogger(true);
+
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'BDAT' }, 'C:', 'BDAT 100');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '500 Error: command not recognized');
+
+        test.equal(entries.length, 3);
+        test.deepEqual(entries[0], { level: 'silly', prefix: smtpInterface.options.name, message: 'C: BDAT 100' });
+        test.equal(entries[1].level, 'info');
+        test.deepEqual(entries[2], {
+            level: 'silly',
+            prefix: smtpInterface.options.name,
+            message: 'S: 500 Error: command not recognized'
+        });
+    });
+    test.done();
+};
+
+module.exports['SMTP setup installs the rejection logger when the transcript is disabled'] = test => {
+    let originalHandler = plugins.handler;
+    let originalInfo = log.info;
+    let entries = [];
+
+    plugins.handler = {
+        runHooks(name, args, callback) {
+            setImmediate(callback);
+        }
+    };
+    log.info = (...args) => entries.push({ prefix: args[0], message: util.format(...args.slice(1)) });
+
+    let smtpInterface = new SMTPInterface(
+        'feeder',
+        {
+            name: 'feeder',
+            hostname: 'localhost',
+            logger: false,
+            authentication: false,
+            starttls: false,
+            secure: false
+        },
+        false
+    );
+
+    smtpInterface.setup(err => {
+        test.ifError(err);
+
+        smtpInterface.server.logger.debug({ tnx: 'command', cid: 'setup-connection', command: 'BDAT' }, 'C:', 'BDAT 100');
+        smtpInterface.server.logger.debug({ tnx: 'send', cid: 'setup-connection' }, 'S:', '500 Error: command not recognized');
+
+        test.equal(entries.length, 1);
+        test.equal(entries[0].prefix, smtpInterface.logName);
+        test.ok(/command="BDAT"/.test(entries[0].message));
+
+        plugins.handler = originalHandler;
+        log.info = originalInfo;
+        smtpInterface.close(() => test.done());
+    });
+};

--- a/test/smtp-interface-test.js
+++ b/test/smtp-interface-test.js
@@ -1,25 +1,8 @@
 'use strict';
 
-const util = require('util');
-const log = require('npmlog');
 const SMTPInterface = require('../lib/smtp-interface');
 const plugins = require('../lib/plugins');
-
-function captureLogs(callback) {
-    let originalInfo = log.info;
-    let originalSilly = log.silly;
-    let entries = [];
-
-    log.info = (...args) => entries.push({ level: 'info', prefix: args[0], message: util.format(...args.slice(1)) });
-    log.silly = (...args) => entries.push({ level: 'silly', prefix: args[0], message: util.format(...args.slice(1)) });
-
-    try {
-        return callback(entries);
-    } finally {
-        log.info = originalInfo;
-        log.silly = originalSilly;
-    }
-}
+const captureLogs = require('./fixtures/capture-logs');
 
 function createLogger(loggerEnabled) {
     let smtpInterface = new SMTPInterface('feeder', { name: 'feeder', logger: loggerEnabled }, false);
@@ -37,8 +20,7 @@ module.exports['SMTP logger records rejected responses when the transcript is di
             {
                 level: 'info',
                 prefix: smtpInterface.logName,
-                message:
-                    'SMTPRESPONSE id="test-connection" user="sender@example.com" command="BDAT" response="500 Error: command not recognized"'
+                message: 'SMTPRESPONSE id=test-connection user="sender@example.com" command="BDAT" response="500 Error: command not recognized"'
             }
         ]);
     });
@@ -78,15 +60,116 @@ module.exports['SMTP logger never records AUTH continuation payloads in rejectio
 
         logger.debug({ tnx: 'command', cid: 'test-connection', command: 'AUTH' }, 'C:', 'AUTH LOGIN');
         logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '334 VXNlcm5hbWU6');
-        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'dXNlckBleGFtcGxlLmNvbQ==' }, 'C:', 'dXNlckBleGFtcGxlLmNvbQ==');
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'DXNLCKBLEGFTCGXLLMNVBQ==' }, 'C:', 'dXNlckBleGFtcGxlLmNvbQ==');
         logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '334 UGFzc3dvcmQ6');
-        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'c2VjcmV0' }, 'C:', 'c2VjcmV0');
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'C2VJCMV0' }, 'C:', 'c2VjcmV0');
         logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '535 Error: Authentication credentials invalid');
 
         test.equal(entries.length, 1);
         test.ok(/command="AUTH"/.test(entries[0].message));
-        test.ok(!/dXNlckBleGFtcGxlLmNvbQ==/.test(entries[0].message));
-        test.ok(!/c2VjcmV0/.test(entries[0].message));
+        test.ok(!/DXNLCKBLEGFTCGXLLMNVBQ/.test(entries[0].message));
+        test.ok(!/C2VJCMV0/.test(entries[0].message));
+    });
+    test.done();
+};
+
+// smtp-server only emits a 334 when AUTH is supported. With authentication disabled AUTH is in
+// disabledCommands, so a client that pipelines the whole exchange gets a 500 per continuation line
+// and the base64 credentials must still stay out of the log
+module.exports['SMTP logger never records AUTH payloads pipelined without a challenge'] = test => {
+    captureLogs(entries => {
+        let { logger } = createLogger(false);
+
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'AUTH' }, 'C:', 'AUTH LOGIN');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '500 Error: command not recognized');
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'DXNLCKBLEGFTCGXLLMNVBQ==' }, 'C:', 'dXNlckBleGFtcGxlLmNvbQ==');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '500 Error: command not recognized');
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'C2VJCMV0' }, 'C:', 'c2VjcmV0');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '500 Error: command not recognized');
+
+        test.equal(entries.length, 3);
+        test.ok(/command="AUTH"/.test(entries[0].message));
+        entries.forEach(entry => {
+            test.ok(!/DXNLCKBLEGFTCGXLLMNVBQ/.test(entry.message));
+            test.ok(!/C2VJCMV0/.test(entry.message));
+        });
+    });
+    test.done();
+};
+
+// meta.command is the uppercased first token of the raw client input, not a validated verb
+module.exports['SMTP logger never echoes unknown client commands'] = test => {
+    captureLogs(entries => {
+        let { logger } = createLogger(false);
+
+        let junk = 'A'.repeat(4000);
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: junk }, 'C:', junk);
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '500 Error: command not recognized');
+
+        test.equal(entries.length, 1);
+        test.ok(/command=""/.test(entries[0].message));
+        test.ok(!/AAAA/.test(entries[0].message));
+    });
+    test.done();
+};
+
+// An unknown token must not inherit the attribution of the command that came before it
+module.exports['SMTP logger does not attribute an unknown command to the previous one'] = test => {
+    captureLogs(entries => {
+        let { logger } = createLogger(false);
+
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'EHLO' }, 'C:', 'EHLO client.example.com');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '250 OK');
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'NOTACOMMAND' }, 'C:', 'NOTACOMMAND');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '500 Error: command not recognized');
+
+        test.equal(entries.length, 1);
+        test.ok(/command=""/.test(entries[0].message));
+    });
+    test.done();
+};
+
+module.exports['SMTP logger quotes response text that contains quotes'] = test => {
+    captureLogs(entries => {
+        let { logger } = createLogger(false);
+
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'RCPT' }, 'C:', 'RCPT TO:<user@example.com>');
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '550 Unknown "recipient"');
+
+        test.equal(entries.length, 1);
+        test.ok(/response="550 Unknown \\"recipient\\""/.test(entries[0].message));
+    });
+    test.done();
+};
+
+module.exports['SMTP logger forgets the command state of a closed connection'] = test => {
+    captureLogs(entries => {
+        let { logger } = createLogger(false);
+
+        logger.debug({ tnx: 'command', cid: 'test-connection', command: 'MAIL' }, 'C:', 'MAIL FROM:<sender@example.com>');
+        logger.info({ tnx: 'close', cid: 'test-connection' }, 'Connection closed to %s', 'client.example.com');
+
+        // reusing the id proves the entry is gone instead of being carried over
+        logger.debug({ tnx: 'send', cid: 'test-connection' }, 'S:', '421 Server shutting down');
+
+        test.equal(entries.length, 1);
+        test.ok(/command=""/.test(entries[0].message));
+    });
+    test.done();
+};
+
+module.exports['SMTP logger tracks connections independently'] = test => {
+    captureLogs(entries => {
+        let { logger } = createLogger(false);
+
+        logger.debug({ tnx: 'command', cid: 'connection-a', command: 'MAIL' }, 'C:', 'MAIL FROM:<sender@example.com>');
+        logger.debug({ tnx: 'command', cid: 'connection-b', command: 'RCPT' }, 'C:', 'RCPT TO:<user@example.com>');
+        logger.debug({ tnx: 'send', cid: 'connection-b' }, 'S:', '550 No such user');
+        logger.debug({ tnx: 'send', cid: 'connection-a' }, 'S:', '451 Try again later');
+
+        test.equal(entries.length, 2);
+        test.ok(/id=connection-b .* command="RCPT"/.test(entries[0].message));
+        test.ok(/id=connection-a .* command="MAIL"/.test(entries[1].message));
     });
     test.done();
 };
@@ -112,15 +195,17 @@ module.exports['SMTP logger preserves the optional full transcript'] = test => {
 
 module.exports['SMTP setup installs the rejection logger when the transcript is disabled'] = test => {
     let originalHandler = plugins.handler;
-    let originalInfo = log.info;
     let entries = [];
+
+    let restore = () => {
+        plugins.handler = originalHandler;
+    };
 
     plugins.handler = {
         runHooks(name, args, callback) {
             setImmediate(callback);
         }
     };
-    log.info = (...args) => entries.push({ prefix: args[0], message: util.format(...args.slice(1)) });
 
     let smtpInterface = new SMTPInterface(
         'feeder',
@@ -135,18 +220,34 @@ module.exports['SMTP setup installs the rejection logger when the transcript is 
         false
     );
 
-    smtpInterface.setup(err => {
+    let done = err => {
+        restore();
         test.ifError(err);
+        test.done();
+    };
 
-        smtpInterface.server.logger.debug({ tnx: 'command', cid: 'setup-connection', command: 'BDAT' }, 'C:', 'BDAT 100');
-        smtpInterface.server.logger.debug({ tnx: 'send', cid: 'setup-connection' }, 'S:', '500 Error: command not recognized');
+    // setup() reaches its callback asynchronously, so plugins.handler is restored from there
+    smtpInterface.setup(err => {
+        if (err) {
+            return done(err);
+        }
 
-        test.equal(entries.length, 1);
-        test.equal(entries[0].prefix, smtpInterface.logName);
-        test.ok(/command="BDAT"/.test(entries[0].message));
+        try {
+            captureLogs(captured => {
+                entries = captured;
+                // the logger reaches smtp-server through the constructor, wrapped by nodemailer
+                smtpInterface.server.logger.debug({ tnx: 'command', cid: 'setup-connection', command: 'BDAT' }, 'C:', 'BDAT 100');
+                smtpInterface.server.logger.debug({ tnx: 'send', cid: 'setup-connection' }, 'S:', '500 Error: command not recognized');
+            });
 
-        plugins.handler = originalHandler;
-        log.info = originalInfo;
-        smtpInterface.close(() => test.done());
+            test.equal(entries.length, 1);
+            test.equal(entries[0].level, 'info');
+            test.equal(entries[0].prefix, smtpInterface.logName);
+            test.ok(/command="BDAT"/.test(entries[0].message));
+        } catch (E) {
+            return done(E);
+        }
+
+        smtpInterface.close(() => done());
     });
 };

--- a/test/smtp-proxy-test.js
+++ b/test/smtp-proxy-test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const SMTPProxy = require('../lib/receiver/smtp-proxy');
+const captureLogs = require('./fixtures/capture-logs');
+
+// A socket handed to the proxy before it ever reaches an SMTP server. Nothing else records
+// these connections, so socketEnd is the only place the refusal can be logged.
+function fakeSocket() {
+    let socket = {
+        remoteAddress: '203.0.113.10',
+        written: false,
+        end(data) {
+            socket.written = data;
+        },
+        destroy() {
+            socket.destroyed = true;
+        }
+    };
+    return socket;
+}
+
+module.exports['SMTP proxy logs connections it refuses'] = test => {
+    captureLogs(entries => {
+        let proxy = new SMTPProxy('feeder', { name: 'feeder' });
+        let socket = fakeSocket();
+
+        proxy.socketEnd(socket, '421 No free process to handle connection');
+
+        test.equal(socket.written, '421 No free process to handle connection\r\n');
+        test.equal(entries.length, 1);
+        test.equal(entries[0].level, 'info');
+        test.equal(entries[0].prefix, proxy.logName);
+        test.equal(entries[0].message, 'SMTPREJECT src=203.0.113.10 response="421 No free process to handle connection"');
+    });
+    test.done();
+};
+
+module.exports['SMTP proxy logs the refusal of a shutting down server'] = test => {
+    captureLogs(entries => {
+        let proxy = new SMTPProxy('feeder', { name: 'feeder' });
+        proxy.closing = true;
+        let socket = fakeSocket();
+
+        proxy.connection(socket);
+
+        test.equal(socket.written, '421 Server shutting down\r\n');
+        test.equal(entries.length, 1);
+        test.ok(/SMTPREJECT src=203\.0\.113\.10 response="421 Server shutting down"/.test(entries[0].message));
+    });
+    test.done();
+};
+
+module.exports['SMTP proxy logs the refusal when no receiver process is available'] = test => {
+    captureLogs(entries => {
+        let proxy = new SMTPProxy('feeder', { name: 'feeder' });
+        let socket = fakeSocket();
+
+        proxy.connection(socket);
+
+        test.equal(socket.written, '421 No free process to handle connection\r\n');
+        test.equal(entries.length, 1);
+        test.ok(/response="421 No free process to handle connection"/.test(entries[0].message));
+    });
+    test.done();
+};


### PR DESCRIPTION
Tries to fix #501

## Follow-up: review fixes (95b5623)

The first version echoed `meta.command` into the log. smtp-server builds that from the first token of the raw client input, not from a validated verb, so it carried two problems:

* an unauthenticated client could write up to 4 KB of arbitrary text per command into the info log, with no way to turn it off;
* the base64 AUTH payloads were only shielded by having seen a 334 challenge, but the shipped default is `authentication: false`, which disables AUTH so no 334 is ever sent. A pipelined `AUTH LOGIN` then logged the encoded username and password.

`meta.command` is now logged only when it is a known SMTP verb, which closes both.

The PR also did not cover the refusals that never reach an SMTP server at all: `smtp-proxy.socketEnd` and `receiver.closeSocket` answer `421` straight on the socket, so child exhaustion and rolling restarts refused clients with no record. Both now log through a shared helper. Those are the only two places outside the SMTP server that write an SMTP response to a socket.

Smaller items: the logger is passed to the `SMTPServer` constructor instead of overwriting `server.logger` afterwards; `id=` is emitted bare to match `CONNECTION`/`AUTHFAIL`/`AUTHSUCCESS`; `SMTPProxy.logName` is now actually assigned (existing `log.error` calls read it but nothing ever set it); the config comment is corrected.

Tests go from 6 to 15 cases and cover the pipelined AUTH exchange, unknown verbs, per-connection isolation, close cleanup and the proxy refusals.

Verified against the issue's own repro:

```
info SMTP/feeder/88182 CONNECTION id=qvj6fgc42afrvmg0 src=client[127.0.0.1]:53621 tlsProtocol=No TLS
info SMTP/feeder/88182 SMTPRESPONSE id=qvj6fgc42afrvmg0 user="" command="BDAT" response="500 Error: command not recognized"
info SMTP/feeder/88182 SMTPRESPONSE id=qvj6fgc42afrvmg0 user="" command="AUTH" response="500 Error: command not recognized"
info SMTP/feeder/88182 SMTPRESPONSE id=qvj6fgc42afrvmg0 user="" command="" response="500 Error: command not recognized"
```

The last line is a base64 credential line: refusal recorded, payload not.
