### PR TITLE
fix: guard sockets against async errors during PROXY handoff and refusal

### DIFF
--- a/lib/receiver/smtp-proxy.js
+++ b/lib/receiver/smtp-proxy.js
@@ -89,6 +89,13 @@ class SMTPProxy {
         logSmtpReject(this.logName, socket, message);
 
         let writeToSocket = () => {
+            // A reset peer does not make socket.end() throw synchronously — it emits an
+            // asynchronous 'error' (write ECONNRESET). The try/catch below only covers
+            // synchronous throws, so without an 'error' listener that async event is
+            // unhandled and crashes the whole proxy process. Attach a no-op handler first.
+            socket.on('error', () => {
+                // ignore, the connection is being refused anyway
+            });
             try {
                 socket.end(message + '\r\n');
             } catch (E) {
@@ -112,6 +119,11 @@ class SMTPProxy {
                 });
             }
             if (tlsSocket) {
+                // same async-error hazard as writeToSocket() above: guard the TLS socket
+                // (a distinct object) before writing the rejection to it
+                tlsSocket.on('error', () => {
+                    // ignore, the connection is being refused anyway
+                });
                 try {
                     tlsSocket.end(message + '\r\n');
                 } catch (E) {
@@ -235,6 +247,16 @@ class SMTPProxy {
     }
 
     connection(socket) {
+        // Guard the raw socket the instant it is accepted. A peer can reset the connection
+        // at any point before it is handed to a child worker — HAProxy health checks and
+        // port scanners do exactly this, constantly, on a PROXY-fronted port — and a reset
+        // socket emits an asynchronous 'error' that would otherwise be unhandled and crash
+        // the whole proxy process. This covers the accept→handoff window and the rejection
+        // writes in socketEnd() below.
+        socket.on('error', () => {
+            // ignore — the socket is either being rejected or handed off to a child
+        });
+
         if (this.closing) {
             return this.socketEnd(socket, '421 Server shutting down');
         }
@@ -262,7 +284,13 @@ class SMTPProxy {
         // https://github.com/nodejs/node/issues/8353#issuecomment-244092209
         // if we do not explicitly stop reading from the socket then we might
         // accidentally have some data in buffer that is not available for the child process
-        socket._handle.readStop();
+        try {
+            socket._handle.readStop();
+        } catch (err) {
+            // the peer already tore the connection down before it could be handed off;
+            // the accept-time 'error' guard swallows the trailing error, so just stop here
+            return;
+        }
         let res;
         try {
             res = child.send('socket', socket);

--- a/services/receiver.js
+++ b/services/receiver.js
@@ -36,6 +36,13 @@ let closeSocket = (socket, message) => {
         return;
     }
 
+    // A reset peer surfaces as an asynchronous 'error' on the socket, not a synchronous
+    // throw, so neither the try/catch below nor socket.destroy() stops it from becoming an
+    // unhandled 'error' that crashes the worker process. Attach a no-op handler up front.
+    socket.on('error', () => {
+        // ignore, the connection is being refused anyway
+    });
+
     // The socket never reaches the SMTP server, so nothing else records the refusal. A secure
     // interface can not answer in plaintext and resets below, the refusal is logged either way.
     logSmtpReject(logName, socket, message);
@@ -259,6 +266,12 @@ process.on('message', (m, socket) => {
         // invalid or the peer disconnects before sending a complete one, so release the
         // reference when the socket itself goes away.
         socket.once('close', () => pendingSockets.delete(socket));
+        // Guard the socket until smtp-server takes it over. If the peer resets while the
+        // worker is still initializing (the retry loop below) the socket has no 'error'
+        // listener yet, and an unhandled 'error' would crash the worker.
+        socket.on('error', () => {
+            // ignore — smtp-server attaches its own handlers once it owns the socket
+        });
 
         let passSocket = () =>
             smtpServer.server._handleProxy(socket, (proxyErr, socketOptions) => {

--- a/test/graceful-shutdown-test.js
+++ b/test/graceful-shutdown-test.js
@@ -172,7 +172,9 @@ module.exports['SMTPProxy.spawnReceiver() does not fork after shutdown starts'] 
 
 module.exports['SMTPProxy.connection() rejects sockets after shutdown starts'] = test => {
     let proxy = Object.create(SMTPProxy.prototype);
-    let socket = {};
+    // an EventEmitter: connection() guards the socket with an 'error' listener the instant it
+    // is accepted (real sockets are EventEmitters), before the refusal below
+    let socket = new EventEmitter();
     let response;
     proxy.closing = true;
     proxy.children = new Set([makeChild()]);

--- a/test/smtp-proxy-test.js
+++ b/test/smtp-proxy-test.js
@@ -1,20 +1,23 @@
 'use strict';
 
+const EventEmitter = require('events');
 const SMTPProxy = require('../lib/receiver/smtp-proxy');
 const captureLogs = require('./fixtures/capture-logs');
 
 // A socket handed to the proxy before it ever reaches an SMTP server. Nothing else records
-// these connections, so socketEnd is the only place the refusal can be logged.
+// these connections, so socketEnd is the only place the refusal can be logged. It is an
+// EventEmitter because the proxy attaches an 'error' listener to it: a reset peer surfaces as
+// an asynchronous 'error', not a synchronous throw, so the socket must never be held without
+// one.
 function fakeSocket() {
-    let socket = {
-        remoteAddress: '203.0.113.10',
-        written: false,
-        end(data) {
-            socket.written = data;
-        },
-        destroy() {
-            socket.destroyed = true;
-        }
+    let socket = new EventEmitter();
+    socket.remoteAddress = '203.0.113.10';
+    socket.written = false;
+    socket.end = data => {
+        socket.written = data;
+    };
+    socket.destroy = () => {
+        socket.destroyed = true;
     };
     return socket;
 }
@@ -60,6 +63,37 @@ module.exports['SMTP proxy logs the refusal when no receiver process is availabl
         test.equal(socket.written, '421 No free process to handle connection\r\n');
         test.equal(entries.length, 1);
         test.ok(/response="421 No free process to handle connection"/.test(entries[0].message));
+    });
+    test.done();
+};
+
+// Regression: a peer that resets the connection while it is being refused emits an
+// asynchronous 'error' on the socket. socketEnd() must attach an 'error' listener before it
+// writes the reply, otherwise the emit has no listener and Node turns it into an unhandled
+// 'error' that crashes the whole proxy process (the try/catch around socket.end() only covers
+// synchronous throws). Emitting 'error' here throws unless the listener is in place.
+module.exports['SMTP proxy survives a socket error while refusing a connection'] = test => {
+    captureLogs(() => {
+        let proxy = new SMTPProxy('feeder', { name: 'feeder' });
+        let socket = fakeSocket();
+
+        proxy.socketEnd(socket, '421 No free process to handle connection');
+
+        test.doesNotThrow(() => socket.emit('error', new Error('write ECONNRESET')));
+    });
+    test.done();
+};
+
+// Regression: connection() must guard the socket the instant it is accepted, before any
+// handoff or refusal, so a reset in the accept→handoff window cannot crash the proxy.
+module.exports['SMTP proxy survives a socket error during handoff'] = test => {
+    captureLogs(() => {
+        let proxy = new SMTPProxy('feeder', { name: 'feeder' });
+        let socket = fakeSocket();
+
+        proxy.connection(socket);
+
+        test.doesNotThrow(() => socket.emit('error', new Error('write ECONNRESET')));
     });
     test.done();
 };


### PR DESCRIPTION
The proxy holds a raw socket with no `error` listener while it hands the
connection to a child worker or refuses it with a `421`. When the peer resets in
that window — which health checks and scanners do constantly on a PROXY-fronted
port — `socket.end()` fails asynchronously (`write ECONNRESET`). The surrounding
`try/catch` only catches synchronous throws, so the unhandled `error` takes down
the whole process.

I hit this in production behind HAProxy (`send-proxy` submission backends): the
process crash-looped `write ECONNRESET`
thrown from `socketEnd`. The `check-send-proxy` health checks are one source, but
any client that opens a PROXY connection and drops triggers it too, so removing
the health check alone is not enough.

The fix attaches a no-op `error` listener before those writes and the moment a
socket is accepted. `test/smtp-proxy-test.js` covers it: the new cases fail
without the guards and pass with them.
